### PR TITLE
Add 'cookie' project to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ projects:
      maintainer: dougwilson
  - content-disposition
  - forwarded
+ - cookie
  - media-typer
  - mime-types:
      maintainer: jongleberry


### PR DESCRIPTION
It would be nice to have https://jshttp.github.io/  as one place to see all low-level http staff from jshttp. So I added 'cookie' project as it was not there.